### PR TITLE
Fix broken serializer; remove duplicate URL path; refresh .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,92 @@
-mysite/mysite/secrets.py
+# See also
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+# https://github.com/django/django/blob/master/.gitignore
+# https://www.gitignore.io/api/django,python,intellij (bloated)
+
+### Django ###
+*.log
+*.pot
+*.pyc
+__pycache__/
+local_settings.py
+db.sqlite3
+media
+
+### Django secrets ###
+**/secrets.py
+
+### Intellij ###
+.idea/
+*.iml
+*.ipr
+*.iws
+*.uml
+out/
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environments
+venv/
+venv.bak/
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/mysite/refconn/urls.py
+++ b/mysite/refconn/urls.py
@@ -18,7 +18,6 @@ urlpatterns = [
     path('daily/', views.DupcFilterView.as_view(), name='dupc_filter'),
     path('monthly/<int:pk>/', views.MupcDetailView.as_view(), name='mupc_detail'),
     path('daily/<int:pk>/', views.DupcDetailView.as_view(), name='dupc_detail'),
-    path('auth/', include('social_django.urls', namespace='social')),
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), {'next_page': settings.LOGOUT_REDIRECT_URL},name='logout'),
 ]


### PR DESCRIPTION
This PR fixes (mostly) a broken serializer; remove a duplicate URL `path`;  and refreshes .gitignore so that it ignore `venv/` and other directories and files that should not be committed to an upstream repo.

Both the serializer `create` (POST) and `update` (PUT) methods were broken.  Both operations hit tables with required property values not included in the payload. The fix eliminates this problem but remains a partial fix requiring further work in order to address  a couple of use cases are not covered (the course might be over but you/we can fix them after the holidays).

```
# TODO BOTH OF THE CHECKS BELOW NEED TO CHECK TWO PROPERTY VALUES
# For refugee nationalities, if the nationality is unchanged but the nationality proportion
# has changed then update.
# For app categories, if the app category is unchanged but the total usage in kb has
# changed, then update.
```

### Example API errors encountered

![image](https://user-images.githubusercontent.com/83268/50366506-0b7c7200-0548-11e9-90e5-6a5a9a58c535.png)

![image](https://user-images.githubusercontent.com/83268/50366511-1800ca80-0548-11e9-83b9-ad7569a19feb.png)

![image](https://user-images.githubusercontent.com/83268/50366512-1df6ab80-0548-11e9-8a60-6824993bbd7c.png)


